### PR TITLE
Edge labels

### DIFF
--- a/src/state-diagram/StateGraph.js
+++ b/src/state-diagram/StateGraph.js
@@ -101,7 +101,7 @@ function normalize(state, symbol, instruction) {
 function labelFor(symbols, action) {
   var rightSide = ((action.symbol == null) ? '' : (visibleSpace(String(action.symbol)) + ','))
     + String(action.move);
-  return symbols.map(visibleSpace).join(',') + '→' + rightSide;
+  return symbols.map(visibleSpace).join(',') + ',' + rightSide;
 }
 
 // replace ' ' with '␣'.


### PR DESCRIPTION
Replaced the arrow in the edge label with a comma. Looks better (less confusing) and is also closer to how TMs are represented in SLC.